### PR TITLE
Fix jquery version 3.5.0 error

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
         "bootstrap-datepicker": "1.9.0",
         "headroom.js": "0.10.3",
         "jarallax": "1.12.0",
-        "jquery": "3.5.0",
+        "jquery": "3.5.1",
         "jquery-countdown": "2.2.0",
         "jquery-validation": "1.19.1",
         "jquery.counterup": "2.1.0",


### PR DESCRIPTION
Correction of errors in hamburger menu in mobile version and accordions due to changes in jquery version `3.5.0`